### PR TITLE
Move credential store to Google Secret Manager from Cloud KMS and Google Storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,7 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# VSCode
+.vscode
+

--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,42 @@
 SHELL := /bin/bash
+GOOGLE_CLOUD_PROJECT := $(shell gcloud config get-value project)
+
+init:
+	@gcloud services enable \
+		cloudfunctions.googleapis.com \
+  		secretmanager.googleapis.com || true
+	@gcloud iam service-accounts create cloud-build-status || true
+	@gcloud projects add-iam-policy-binding ${GOOGLE_CLOUD_PROJECT} \
+		--member="serviceAccount:cloud-build-status@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com" \
+		--role="roles/secretmanager.secretAccessor" || true
+
+delete-sa:
+	@gcloud projects remove-iam-policy-binding ${GOOGLE_CLOUD_PROJECT} \
+		--member="serviceAccount:cloud-build-status@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com" \
+		--role="roles/secretmanager.secretAccessor" || true
+	@gcloud iam service-accounts delete cloud-build-status@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com || true
+
+create:
+	@read -p "Provider [github or bitbucket]: " provider; \
+	read -p "Username: " username; \
+	read -s -p "Password: " password; \
+	echo "{\"username\": \"$$username\", \"password\": \"$$password\"}" | \
+		gcloud secrets create $$provider --data-file=-
+
+delete:
+	@read -p "Provider [github or bitbucket]: " provider; \
+	gcloud secrets delete $$provider || true
 
 rotate:
 	@read -p "Provider [github or bitbucket]: " provider; \
 	read -p "Username: " username; \
 	read -s -p "Password: " password; \
 	echo "{\"username\": \"$$username\", \"password\": \"$$password\"}" | \
-		gcloud kms encrypt \
-		--location global \
-		--keyring=${BUILD_STATUS_KEYRING} \
-		--key=${BUILD_STATUS_KEY} \
-		--ciphertext-file=- \
-		--plaintext-file=- | \
-		gsutil cp - gs://${CREDENTIALS_BUCKET}/$$provider
+		gcloud secrets versions add $$provider --data-file=-
 
 decrypt:
 	@read -p "Provider [github or bitbucket]: " provider; \
-	gsutil cp gs://${CREDENTIALS_BUCKET}/$$provider - | \
-		gcloud kms decrypt \
-		--location global \
-		--keyring=${BUILD_STATUS_KEYRING} \
-		--key=${BUILD_STATUS_KEY} \
-		--ciphertext-file=- \
-		--plaintext-file=-
+	gcloud secrets versions access latest --secret $$provider
 
 deploy:
 	gcloud functions deploy \
@@ -30,7 +45,6 @@ deploy:
 		--runtime python37 \
 		--entry-point build_status \
 		--service-account cloud-build-status@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com \
-		--set-env-vars KMS_CRYPTO_KEY_ID=${KMS_CRYPTO_KEY_ID},CREDENTIALS_BUCKET=${CREDENTIALS_BUCKET} \
 		--trigger-topic=cloud-builds
 
 unit:

--- a/cloud_build_status/credentials.py
+++ b/cloud_build_status/credentials.py
@@ -1,30 +1,17 @@
-from google.cloud import kms_v1, storage, exceptions
 import json
 import os
 
-
-def get_ciphertext(bucket_name, obj):
-    client = storage.Client()
-
-    try:
-        bucket = client.get_bucket(bucket_name)
-    except exceptions.NotFound:
-        raise RuntimeError(f"Could not find bucket {bucket_name}")
-
-    blob = bucket.get_blob(obj)
-    if blob is None:
-        raise RuntimeError(f"Could not find object {obj} in bucket {bucket_name}")
-
-    return blob.download_as_string()
+from google.cloud import secretmanager
 
 
-def decrypt(crypto_key_id, ciphertext):
-    return kms_v1 \
-        .KeyManagementServiceClient() \
-        .decrypt(crypto_key_id, ciphertext) \
-        .plaintext \
-        .decode('utf-8') \
-        .strip()
+def access_secret_version(secret_id, version_id="latest"):
+    client = secretmanager.SecretManagerServiceClient()
+
+    project_id = os.environ['GCP_PROJECT']
+    name = f"projects/{project_id}/secrets/{secret_id}/versions/{version_id}"
+    response = client.access_secret_version(name=name)
+
+    return response.payload.data.decode('UTF-8')
 
 
 class Credentials:
@@ -33,14 +20,8 @@ class Credentials:
     @classmethod
     def get(cls, provider):
         if provider.__name__ not in cls._data:
-            crypto_key_id = os.environ['KMS_CRYPTO_KEY_ID']
-            bucket = os.environ['CREDENTIALS_BUCKET']
-            obj = provider.__name__.lower()
-
-            ciphertext = get_ciphertext(bucket, obj)
-            plaintext = decrypt(crypto_key_id, ciphertext)
-
-            cls._data[provider.__name__] = json.loads(plaintext)
+            secret_value = access_secret_version(provider.__name__.lower())
+            cls._data[provider.__name__] = json.loads(secret_value)
 
         creds = cls._data[provider.__name__]
 

--- a/cloud_build_status/event.py
+++ b/cloud_build_status/event.py
@@ -11,11 +11,9 @@ class Event:
         decoded = base64.b64decode(event['data']).decode('utf-8')
         self.data = json.loads(decoded)
 
-
     @property
     def state(self):
         return self.data['status']
-
 
     @property
     def resolved_repo_source(self):
@@ -24,36 +22,29 @@ class Event:
         except KeyError:
             raise IrrelevantEvent
 
-
     @property
     def commit(self):
         return self.resolved_repo_source['commitSha']
-
 
     @property
     def mirror(self):
         return self.resolved_repo_source['repoName']
 
-
     @property
     def provider(self):
         return self.mirror.split('_')[0]
-
 
     @property
     def owner(self):
         return self.mirror.split('_')[1]
 
-
     @property
     def repo(self):
         return self.mirror.split('_', 2)[-1]
 
-
     @property
     def url(self):
         return self.data['logUrl']
-
 
     @property
     def build_trigger_id(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-google-cloud-kms
-google-cloud-storage
+google-cloud-secret-manager
 requests


### PR DESCRIPTION
Use Google Secret Manager to store and access the Github and Bitbucket credentials instead of Cloud KMS and Google Storage.